### PR TITLE
kubernetes needs to be have the server expose to the non-localhost ip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Expose ports
 EXPOSE 25441 25442 25443 
 
-ENTRYPOINT ["/usr/local/bin/python3", "-m", "cryptoadvance.specter", "server"]
+ENTRYPOINT ["/usr/local/bin/python3", "-m", "cryptoadvance.specter", "server", "--host", "0.0.0.0"]


### PR DESCRIPTION
I spend part of the day trying to integrate specter into a Kubernetes environment. 
because specter was listening to localhost only by default, specter was not responding to the call from outside the Pod (but it did with `port-forward` which creates some confusion to me)
I recommend listening by default to all the network interfaces when it's in the Docker. I think this could save some time for others in the future.