### PR TITLE
Migrate Python to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG REPO=https://github.com/cryptoadvance/specter-desktop
 ARG USER=specter
 ARG DIR=/data/
 
-FROM python:3.9-slim-bullseye AS builder
+FROM python:3.10-slim-bullseye AS builder
 
 ARG VERSION
 ARG REPO
@@ -31,7 +31,7 @@ RUN pip3 install babel cryptography
 RUN pip3 install .
 
 
-FROM python:3.9-slim-bullseye as final
+FROM python:3.10-slim-bullseye as final
 
 ARG USER
 ARG DIR
@@ -54,7 +54,7 @@ RUN mkdir -p "$DIR/.specter/"
 
 
 # Copy over python stuff
-COPY --from=builder /usr/local/lib/python3.9 /usr/local/lib/python3.9
+COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 


### PR DESCRIPTION
In Version 2 we've migrated to python 3.10. This should fix the broken builds currently.